### PR TITLE
feat: workspace list view mode and bug fixes

### DIFF
--- a/client/lib/providers/ui_state_provider.dart
+++ b/client/lib/providers/ui_state_provider.dart
@@ -3,21 +3,33 @@ import 'dart:convert';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+/// Workspace 视图模式
+enum WorkspaceViewMode {
+  card, // 卡片视图（展开显示 sessions）
+  list, // 列表视图（点击进入详情页）
+}
+
 /// UI 状态（展开状态等）
 class UIState {
   /// workspace 展开状态 (workspaceKey -> isExpanded)
   /// workspaceKey 格式: "serverId:workspaceId"
   final Map<String, bool> workspaceExpanded;
 
+  /// workspace 视图模式
+  final WorkspaceViewMode workspaceViewMode;
+
   const UIState({
     this.workspaceExpanded = const {},
+    this.workspaceViewMode = WorkspaceViewMode.card,
   });
 
   UIState copyWith({
     Map<String, bool>? workspaceExpanded,
+    WorkspaceViewMode? workspaceViewMode,
   }) {
     return UIState(
       workspaceExpanded: workspaceExpanded ?? this.workspaceExpanded,
+      workspaceViewMode: workspaceViewMode ?? this.workspaceViewMode,
     );
   }
 
@@ -43,7 +55,14 @@ class UIStateNotifier extends StateNotifier<UIState> {
         final data = jsonDecode(json) as Map<String, dynamic>;
         final expanded = (data['workspaceExpanded'] as Map<String, dynamic>?)
             ?.map((k, v) => MapEntry(k, v as bool)) ?? {};
-        state = state.copyWith(workspaceExpanded: expanded);
+        final viewModeStr = data['workspaceViewMode'] as String?;
+        final viewMode = viewModeStr == 'list'
+            ? WorkspaceViewMode.list
+            : WorkspaceViewMode.card;
+        state = state.copyWith(
+          workspaceExpanded: expanded,
+          workspaceViewMode: viewMode,
+        );
       }
     } catch (e) {
       // ignore
@@ -56,6 +75,7 @@ class UIStateNotifier extends StateNotifier<UIState> {
       final prefs = await SharedPreferences.getInstance();
       final data = {
         'workspaceExpanded': state.workspaceExpanded,
+        'workspaceViewMode': state.workspaceViewMode.name,
       };
       await prefs.setString(_storageKey, jsonEncode(data));
     } catch (e) {
@@ -92,6 +112,21 @@ class UIStateNotifier extends StateNotifier<UIState> {
   void expandAll(List<String> workspaceKeys) {
     final newExpanded = {for (var key in workspaceKeys) key: true};
     state = state.copyWith(workspaceExpanded: newExpanded);
+    _save();
+  }
+
+  /// 切换视图模式
+  void toggleViewMode() {
+    final newMode = state.workspaceViewMode == WorkspaceViewMode.card
+        ? WorkspaceViewMode.list
+        : WorkspaceViewMode.card;
+    state = state.copyWith(workspaceViewMode: newMode);
+    _save();
+  }
+
+  /// 设置视图模式
+  void setViewMode(WorkspaceViewMode mode) {
+    state = state.copyWith(workspaceViewMode: mode);
     _save();
   }
 }

--- a/client/lib/router.dart
+++ b/client/lib/router.dart
@@ -11,14 +11,20 @@ import 'screens/session_screen.dart';
 import 'screens/settings_screen.dart';
 import 'screens/file_manager_screen.dart';
 import 'screens/file_viewer_screen.dart';
+import 'screens/workspace_detail_screen.dart';
 
 /// 路由路径常量
 class AppRoutes {
   static const home = '/';
   static const settings = '/settings';
+  static const workspace = '/workspace/:serverId/:workspaceId';
   static const session = '/session/:serverId/:workspaceId/:sessionId';
   static const files = '/files/:serverId/:workspaceId';
   static const fileViewer = '/files/:serverId/:workspaceId/view';
+
+  /// 构建 workspace 详情路径
+  static String workspacePath(String serverId, String workspaceId) =>
+      '/workspace/$serverId/$workspaceId';
 
   /// 构建 session 路径
   static String sessionPath(String serverId, String workspaceId, String sessionId) =>
@@ -51,6 +57,36 @@ final routerProvider = Provider<GoRouter>((ref) {
         path: AppRoutes.settings,
         name: 'settings',
         builder: (context, state) => const SettingsScreen(),
+      ),
+
+      // Workspace 详情页（列表模式）
+      GoRoute(
+        path: AppRoutes.workspace,
+        name: 'workspace',
+        builder: (context, state) {
+          final serverId = state.pathParameters['serverId']!;
+          final workspaceId = state.pathParameters['workspaceId']!;
+
+          final container = ProviderScope.containerOf(context);
+          final serverState = container.read(serverProvider);
+          final server = serverState.getServer(serverId);
+
+          if (server == null) {
+            return const HomeScreen();
+          }
+
+          final workspaces = serverState.getWorkspaces(serverId);
+          final workspace = workspaces.where((w) => w.id == workspaceId).firstOrNull;
+
+          if (workspace == null) {
+            return const HomeScreen();
+          }
+
+          return WorkspaceDetailScreen(
+            server: server,
+            workspace: workspace,
+          );
+        },
       ),
 
       // Session 页面

--- a/client/lib/screens/home_screen.dart
+++ b/client/lib/screens/home_screen.dart
@@ -9,6 +9,7 @@ import '../models/chat_session.dart';
 import '../models/server_config.dart';
 import '../models/workspace.dart';
 import '../providers/providers.dart';
+import '../providers/ui_state_provider.dart';
 import '../router.dart';
 import '../widgets/command_target.dart';
 
@@ -248,6 +249,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   Widget build(BuildContext context) {
     final serverState = ref.watch(serverProvider);
     final sessionState = ref.watch(sessionProvider);
+    final uiState = ref.watch(uiStateProvider);
+    final viewMode = uiState.workspaceViewMode;
 
     return ScreenScope(
       screenId: 'home',
@@ -255,6 +258,18 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         appBar: AppBar(
           title: const Text('Mule'),
           actions: [
+            // 视图切换按钮
+            IconButton(
+              icon: Icon(
+                viewMode == WorkspaceViewMode.card
+                    ? Icons.view_list_outlined
+                    : Icons.grid_view_outlined,
+              ),
+              onPressed: () {
+                ref.read(uiStateProvider.notifier).toggleViewMode();
+              },
+              tooltip: viewMode == WorkspaceViewMode.card ? 'List View' : 'Card View',
+            ),
             IconButton(
               icon: const Icon(Icons.refresh),
               onPressed: () async {
@@ -277,7 +292,9 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         ),
         body: serverState.servers.isEmpty
             ? _buildEmptyServers()
-            : _buildWorkspaceCards(serverState, sessionState),
+            : viewMode == WorkspaceViewMode.card
+                ? _buildWorkspaceCards(serverState, sessionState)
+                : _buildWorkspaceList(serverState, sessionState),
         floatingActionButton: serverState.servers.isEmpty
             ? null
             : FloatingActionButton(
@@ -418,6 +435,70 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
             label: const Text('Refresh'),
           ),
         ],
+      ),
+    );
+  }
+
+  /// 列表视图模式 - 点击进入 workspace 详情页
+  Widget _buildWorkspaceList(
+    ServerState serverState,
+    SessionState sessionState,
+  ) {
+    // 收集所有 workspace
+    final workspaceList = <_WorkspaceCardData>[];
+
+    for (final server in serverState.servers) {
+      final workspaces = serverState.getWorkspaces(server.id);
+      final isOnline = serverState.isServerOnline(server.id);
+
+      for (final ws in workspaces) {
+        final sessions = sessionState.getSessionsForWorkspace(server.id, ws.id);
+
+        workspaceList.add(_WorkspaceCardData(
+          server: server,
+          workspaceId: ws.id,
+          workspaceName: ws.name,
+          sessions: sessions,
+          isServerOnline: isOnline,
+        ));
+      }
+    }
+
+    // 排序：default workspace 在最上面
+    workspaceList.sort((a, b) {
+      if (a.workspaceId == 'default' && b.workspaceId != 'default') return -1;
+      if (a.workspaceId != 'default' && b.workspaceId == 'default') return 1;
+      return a.workspaceName.compareTo(b.workspaceName);
+    });
+
+    if (workspaceList.isEmpty) {
+      return _buildNoWorkspaces();
+    }
+
+    return RefreshIndicator(
+      onRefresh: () async {
+        final serverWorkspaces = await ref.read(serverProvider.notifier).refreshAllServers();
+        await _syncAllSessions(serverWorkspaces);
+      },
+      child: ListView.separated(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        itemCount: workspaceList.length,
+        separatorBuilder: (_, __) => const Divider(height: 1),
+        itemBuilder: (context, index) {
+          final data = workspaceList[index];
+          return _WorkspaceListTile(
+            data: data,
+            onTap: () {
+              context.push(AppRoutes.workspacePath(
+                data.server.id,
+                data.workspaceId,
+              ));
+            },
+            onDelete: data.workspaceId != 'default'
+                ? () => _confirmDeleteWorkspace(data)
+                : null,
+          );
+        },
       ),
     );
   }
@@ -1527,6 +1608,124 @@ class _CreateWorkspaceSheetState extends ConsumerState<_CreateWorkspaceSheet> {
                   )
                 : const Text('Create Workspace'),
           ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Workspace 列表项（用于列表视图模式）
+class _WorkspaceListTile extends StatelessWidget {
+  final _WorkspaceCardData data;
+  final VoidCallback onTap;
+  final VoidCallback? onDelete;
+
+  const _WorkspaceListTile({
+    required this.data,
+    required this.onTap,
+    this.onDelete,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      onTap: onTap,
+      leading: Container(
+        width: 44,
+        height: 44,
+        decoration: BoxDecoration(
+          color: ZiaOlive.shade500.withValues(alpha: 0.1),
+          borderRadius: BorderRadius.circular(10),
+        ),
+        child: Icon(
+          data.workspaceId == 'default'
+              ? Icons.home_outlined
+              : Icons.folder_outlined,
+          color: ZiaOlive.shade500,
+        ),
+      ),
+      title: Row(
+        children: [
+          Flexible(
+            child: Text(
+              data.workspaceName,
+              style: const TextStyle(fontWeight: FontWeight.w600),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          if (data.workspaceId == 'default') ...[
+            const SizedBox(width: 8),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+              decoration: BoxDecoration(
+                color: ZiaOlive.shade500.withValues(alpha: 0.1),
+                borderRadius: BorderRadius.circular(4),
+              ),
+              child: Text(
+                'Default',
+                style: TextStyle(
+                  fontSize: 10,
+                  color: ZiaOlive.shade500,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ),
+          ],
+        ],
+      ),
+      subtitle: Row(
+        children: [
+          Container(
+            width: 6,
+            height: 6,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: data.isServerOnline ? ZiaOlive.success : ZiaOlive.error,
+            ),
+          ),
+          const SizedBox(width: 4),
+          Text(
+            data.server.name,
+            style: TextStyle(
+              fontSize: 12,
+              color: ZiaOlive.shade200,
+            ),
+          ),
+          const SizedBox(width: 12),
+          Text(
+            '${data.sessions.length} session${data.sessions.length == 1 ? '' : 's'}',
+            style: TextStyle(
+              fontSize: 12,
+              color: ZiaOlive.shade300,
+            ),
+          ),
+        ],
+      ),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.chevron_right, color: ZiaOlive.shade300),
+          if (onDelete != null)
+            PopupMenuButton<String>(
+              icon: Icon(Icons.more_vert, size: 20, color: ZiaOlive.shade300),
+              onSelected: (value) {
+                if (value == 'delete') {
+                  onDelete!();
+                }
+              },
+              itemBuilder: (context) => [
+                const PopupMenuItem(
+                  value: 'delete',
+                  child: Row(
+                    children: [
+                      Icon(Icons.delete_outline, size: 18, color: Colors.red),
+                      SizedBox(width: 8),
+                      Text('Delete', style: TextStyle(color: Colors.red)),
+                    ],
+                  ),
+                ),
+              ],
+            ),
         ],
       ),
     );

--- a/client/lib/screens/workspace_detail_screen.dart
+++ b/client/lib/screens/workspace_detail_screen.dart
@@ -1,0 +1,414 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../config/theme.dart';
+import '../models/chat_session.dart';
+import '../models/server_config.dart';
+import '../models/workspace.dart';
+import '../providers/providers.dart';
+import '../router.dart';
+import '../widgets/command_target.dart';
+
+/// Workspace 详情页面 - 显示该 workspace 下的所有 sessions
+class WorkspaceDetailScreen extends ConsumerStatefulWidget {
+  final ServerConfig server;
+  final WorkspaceInfo workspace;
+
+  const WorkspaceDetailScreen({
+    super.key,
+    required this.server,
+    required this.workspace,
+  });
+
+  @override
+  ConsumerState<WorkspaceDetailScreen> createState() => _WorkspaceDetailScreenState();
+}
+
+class _WorkspaceDetailScreenState extends ConsumerState<WorkspaceDetailScreen> {
+  @override
+  void initState() {
+    super.initState();
+    // 同步该 workspace 的 sessions
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      ref.read(sessionProvider.notifier).syncSessionsFromServer(
+        widget.server,
+        widget.workspace.id,
+        widget.workspace.name,
+      );
+    });
+  }
+
+  void _openSession(ChatSession session) {
+    ref.read(sessionProvider.notifier).setActiveSession(session.id);
+    context.go(AppRoutes.sessionPath(
+      widget.server.id,
+      widget.workspace.id,
+      session.id,
+    ));
+  }
+
+  void _createNewSession() async {
+    final session = await ref.read(sessionProvider.notifier).createSession(
+      serverId: widget.server.id,
+      workspaceId: widget.workspace.id,
+      workspaceName: widget.workspace.name,
+    );
+
+    if (mounted) {
+      ref.read(sessionProvider.notifier).setActiveSession(session.id);
+      context.go(AppRoutes.sessionPath(
+        widget.server.id,
+        widget.workspace.id,
+        session.id,
+      ));
+    }
+  }
+
+  void _showRenameDialog(ChatSession session) {
+    final controller = TextEditingController(text: session.name);
+
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Rename Session'),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          decoration: const InputDecoration(
+            labelText: 'Session Name',
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () {
+              final newName = controller.text.trim();
+              if (newName.isNotEmpty) {
+                ref.read(sessionProvider.notifier).renameSession(session.id, newName);
+              }
+              Navigator.pop(context);
+            },
+            child: const Text('Save'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _confirmDeleteSession(ChatSession session) {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Delete Session'),
+        content: Text('Delete "${session.name}"?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () {
+              ref.read(sessionProvider.notifier).deleteSession(session.id);
+              Navigator.pop(context);
+            },
+            style: FilledButton.styleFrom(
+              backgroundColor: ZiaOlive.error,
+            ),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final sessionState = ref.watch(sessionProvider);
+    final serverState = ref.watch(serverProvider);
+    final isOnline = serverState.isServerOnline(widget.server.id);
+
+    final sessions = sessionState.getSessionsForWorkspace(
+      widget.server.id,
+      widget.workspace.id,
+    );
+
+    // 按最后活跃时间排序
+    sessions.sort((a, b) => b.lastActiveAt.compareTo(a.lastActiveAt));
+
+    return ScreenScope(
+      screenId: 'workspace_detail',
+      child: Scaffold(
+        appBar: AppBar(
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back),
+            onPressed: () => context.go(AppRoutes.home),
+          ),
+          title: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                widget.workspace.name,
+                style: const TextStyle(fontSize: 18),
+              ),
+              Row(
+                children: [
+                  Container(
+                    width: 6,
+                    height: 6,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: isOnline ? ZiaOlive.success : ZiaOlive.error,
+                    ),
+                  ),
+                  const SizedBox(width: 4),
+                  Text(
+                    widget.server.name,
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: ZiaOlive.shade300,
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+          actions: [
+            IconButton(
+              icon: const Icon(Icons.folder_open_outlined),
+              tooltip: 'Files',
+              onPressed: () {
+                context.push(AppRoutes.filesPath(
+                  widget.server.id,
+                  widget.workspace.id,
+                ));
+              },
+            ),
+            IconButton(
+              icon: const Icon(Icons.refresh),
+              tooltip: 'Refresh',
+              onPressed: () async {
+                await ref.read(sessionProvider.notifier).syncSessionsFromServer(
+                  widget.server,
+                  widget.workspace.id,
+                  widget.workspace.name,
+                );
+              },
+            ),
+          ],
+        ),
+        body: sessions.isEmpty
+            ? _buildEmptySessions()
+            : _buildSessionsList(sessions),
+        floatingActionButton: FloatingActionButton(
+          onPressed: _createNewSession,
+          tooltip: 'New Session',
+          child: const Icon(Icons.add),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildEmptySessions() {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.chat_bubble_outline,
+            size: 64,
+            color: ZiaOlive.shade200,
+          ),
+          const SizedBox(height: 16),
+          Text(
+            'No sessions yet',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Start a new session to begin',
+            style: TextStyle(color: ZiaOlive.shade200),
+          ),
+          const SizedBox(height: 24),
+          FilledButton.icon(
+            onPressed: _createNewSession,
+            icon: const Icon(Icons.add),
+            label: const Text('New Session'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSessionsList(List<ChatSession> sessions) {
+    return RefreshIndicator(
+      onRefresh: () async {
+        await ref.read(sessionProvider.notifier).syncSessionsFromServer(
+          widget.server,
+          widget.workspace.id,
+          widget.workspace.name,
+        );
+      },
+      child: ListView.separated(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        itemCount: sessions.length,
+        separatorBuilder: (_, __) => const Divider(height: 1),
+        itemBuilder: (context, index) {
+          final session = sessions[index];
+          return _SessionListTile(
+            session: session,
+            onTap: () => _openSession(session),
+            onRename: () => _showRenameDialog(session),
+            onDelete: () => _confirmDeleteSession(session),
+          );
+        },
+      ),
+    );
+  }
+}
+
+/// Session 列表项
+class _SessionListTile extends StatelessWidget {
+  final ChatSession session;
+  final VoidCallback onTap;
+  final VoidCallback onRename;
+  final VoidCallback onDelete;
+
+  const _SessionListTile({
+    required this.session,
+    required this.onTap,
+    required this.onRename,
+    required this.onDelete,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isConnected = session.connectionState == SessionConnectionState.connected;
+    final isProcessing = session.isProcessing;
+    final hasUnread = session.hasUnread;
+
+    return ListTile(
+      onTap: onTap,
+      leading: isProcessing
+          ? const SizedBox(
+              width: 24,
+              height: 24,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            )
+          : Container(
+              width: 12,
+              height: 12,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: isConnected ? ZiaOlive.success : ZiaOlive.shade200,
+              ),
+            ),
+      title: Row(
+        children: [
+          Flexible(
+            child: Text(
+              session.name,
+              style: TextStyle(
+                fontWeight: hasUnread ? FontWeight.w700 : FontWeight.w500,
+              ),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          if (hasUnread) ...[
+            const SizedBox(width: 8),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+              decoration: BoxDecoration(
+                color: Colors.red,
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: const Text(
+                'NEW',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 9,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+          ],
+        ],
+      ),
+      subtitle: session.messages.isNotEmpty
+          ? Text(
+              _getLastMessagePreview(session),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                color: hasUnread ? ZiaOlive.shade400 : ZiaOlive.shade200,
+              ),
+            )
+          : null,
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            _formatTime(session.lastActiveAt),
+            style: TextStyle(
+              fontSize: 12,
+              color: ZiaOlive.shade200,
+            ),
+          ),
+          PopupMenuButton<String>(
+            icon: Icon(Icons.more_vert, color: ZiaOlive.shade300),
+            onSelected: (value) {
+              if (value == 'rename') {
+                onRename();
+              } else if (value == 'delete') {
+                onDelete();
+              }
+            },
+            itemBuilder: (context) => [
+              const PopupMenuItem(
+                value: 'rename',
+                child: Row(
+                  children: [
+                    Icon(Icons.edit_outlined, size: 18),
+                    SizedBox(width: 8),
+                    Text('Rename'),
+                  ],
+                ),
+              ),
+              PopupMenuItem(
+                value: 'delete',
+                child: Row(
+                  children: [
+                    Icon(Icons.delete_outline, size: 18, color: Colors.red),
+                    const SizedBox(width: 8),
+                    const Text('Delete', style: TextStyle(color: Colors.red)),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _getLastMessagePreview(ChatSession session) {
+    if (session.messages.isEmpty) return '';
+    final last = session.messages.last;
+    final content = last.content;
+    return content.length > 60 ? '${content.substring(0, 60)}...' : content;
+  }
+
+  String _formatTime(DateTime time) {
+    final now = DateTime.now();
+    final diff = now.difference(time);
+
+    if (diff.inMinutes < 1) return 'now';
+    if (diff.inHours < 1) return '${diff.inMinutes}m';
+    if (diff.inDays < 1) return '${diff.inHours}h';
+    if (diff.inDays < 7) return '${diff.inDays}d';
+    return '${time.month}/${time.day}';
+  }
+}


### PR DESCRIPTION
## Summary
This PR includes multiple features and bug fixes:

### Features
1. **Workspace List View Mode** - Add toggle between card and list view modes
   - Card view: Current expandable cards showing sessions inline
   - List view: Compact workspace list, click to enter detail page
   - View mode preference is persisted locally

2. **Compact Context Debounce** - Prevent multiple clicks during context compaction
   - Shows toast "Compacting in progress..." if already compacting
   - Shows toast "No messages to compact" if no messages

### Bug Fixes
3. **Fix asyncio LimitOverrunError** - Increase stream limit to 128MB
   - Prevents `Separator is not found, and chunk exceed the limit` error
   - Happens when Claude Code outputs large file contents (>64KB)

## Changes
- `app/services/sandbox_agent.py`: Increase asyncio limit to 128MB
- `client/lib/models/chat_session.dart`: Add `isCompacting` field
- `client/lib/providers/session_provider.dart`: Track compacting state
- `client/lib/providers/ui_state_provider.dart`: Add view mode support
- `client/lib/router.dart`: Add workspace detail route
- `client/lib/screens/home_screen.dart`: Add view toggle and list view
- `client/lib/screens/session_screen.dart`: Add compact debounce logic
- `client/lib/screens/workspace_detail_screen.dart`: New detail page

## Test plan
- [ ] Toggle view mode and verify persistence across app restarts
- [ ] In list view, click workspace to enter detail page
- [ ] Verify compact button shows toast when clicked multiple times
- [ ] Read a large file (>64KB) and verify no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)