### PR TITLE
fix: kill claude processes after token refresh

### DIFF
--- a/app/services/sandbox_agent.py
+++ b/app/services/sandbox_agent.py
@@ -186,6 +186,10 @@ class TokenRefresher:
 
                         # 同步到所有容器
                         credentials_watcher._sync_credentials()
+
+                        # 终止所有容器内的 claude 进程，让它们重新读取新 token
+                        await self._kill_claude_processes_in_containers()
+
                         return True
                     else:
                         error_text = await response.text()
@@ -198,6 +202,47 @@ class TokenRefresher:
         except Exception as e:
             logger.error(f"[TokenRefresh] Error: {e}")
             return False
+
+    async def _kill_claude_processes_in_containers(self) -> None:
+        """终止所有容器内的 claude 进程
+
+        Token 刷新后，需要终止运行中的 claude 进程，
+        下次请求时会重新启动并读取新的 credentials。
+        """
+        try:
+            # 获取所有 mule-sandbox 容器
+            result = subprocess.run(
+                ["docker", "ps", "--format", "{{.Names}}", "--filter", "name=mule-sandbox-"],
+                capture_output=True, text=True
+            )
+
+            containers = [name.strip() for name in result.stdout.strip().split('\n') if name.strip()]
+
+            if not containers:
+                logger.debug("[TokenRefresh] No active sandbox containers to update")
+                return
+
+            killed_count = 0
+            for container_name in containers:
+                try:
+                    # 在容器内终止所有 claude 进程
+                    kill_result = subprocess.run(
+                        ["docker", "exec", container_name, "pkill", "-f", "claude"],
+                        capture_output=True, text=True, timeout=5
+                    )
+                    if kill_result.returncode == 0:
+                        killed_count += 1
+                        logger.debug(f"[TokenRefresh] Killed claude process in {container_name}")
+                except subprocess.TimeoutExpired:
+                    logger.warning(f"[TokenRefresh] Timeout killing claude in {container_name}")
+                except Exception as e:
+                    logger.debug(f"[TokenRefresh] Could not kill claude in {container_name}: {e}")
+
+            if killed_count > 0:
+                logger.info(f"[TokenRefresh] Killed claude processes in {killed_count} container(s) - they will restart with new token on next request")
+
+        except Exception as e:
+            logger.error(f"[TokenRefresh] Error killing claude processes: {e}")
 
     async def _update_credentials(self, token_data: dict) -> None:
         """更新 credentials 文件"""


### PR DESCRIPTION
## Summary

Fix the issue where running Claude Code processes don't pick up refreshed OAuth tokens.

## Problem

When the OAuth token is refreshed:
1. `.credentials.json` file is updated
2. File is synced to container directories via `CredentialsWatcher`
3. **But running Claude Code processes still use the old cached token in memory**
4. This causes authentication failures until the user manually restarts

## Solution

After token refresh, kill all `claude` processes in active sandbox containers:
- Use `docker exec pkill -f claude` to terminate processes
- Processes will automatically restart on next user request
- New processes will read the updated credentials file

## Changes

- `app/services/sandbox_agent.py`: Add `_kill_claude_processes_in_containers()` method
- Call this method after successful token refresh in `_refresh_token()`

## Test plan

- [ ] Start a chat session and let it idle
- [ ] Wait for token refresh (or manually trigger by editing token expiry)
- [ ] Verify claude processes are killed (check PM2 logs)
- [ ] Send a new message - should work without requiring re-login

🤖 Generated with [Claude Code](https://claude.com/claude-code)