### PR TITLE
feat(client): improve UI feedback - text selection, tool card expand, pending prompts, cancel behavior

### DIFF
--- a/app/api/websocket.py
+++ b/app/api/websocket.py
@@ -589,13 +589,38 @@ async def _handle_sync(ctx: MessageHandlerContext) -> bool:
 
 
 async def _handle_cancel(ctx: MessageHandlerContext) -> bool:
-    """处理 cancel 消息"""
+    """处理 cancel 消息 - 取消当前任务并清空待处理队列"""
     current_task = task_manager.get_current_task(ctx.task_key)
+
+    # 清空 pending prompts 队列
+    cleared_prompts = []
+    if ctx.task_key in manager.pending_prompts:
+        cleared_prompts = manager.pending_prompts[ctx.task_key]
+        manager.pending_prompts[ctx.task_key] = []
+
     if current_task:
         task_manager.cancel_task(current_task.id)
+
+        # 返回被清空的 prompt 内容，让客户端可以恢复到输入框
+        cleared_contents = [content for _, content in cleared_prompts]
         await manager.send_to_session(ctx.workspace_id, ctx.session_id, {
             "event": "status",
-            "data": {"type": "cancelled", "message": "Task cancelled"}
+            "data": {
+                "type": "cancelled",
+                "message": "Task cancelled",
+                "cleared_prompts": cleared_contents,
+            }
+        }, display_workspace_id=ctx.raw_workspace_id)
+    elif cleared_prompts:
+        # 没有运行中的任务，但有队列中的 prompts 被清空
+        cleared_contents = [content for _, content in cleared_prompts]
+        await manager.send_to_session(ctx.workspace_id, ctx.session_id, {
+            "event": "status",
+            "data": {
+                "type": "cancelled",
+                "message": "Queued prompts cleared",
+                "cleared_prompts": cleared_contents,
+            }
         }, display_workspace_id=ctx.raw_workspace_id)
     else:
         await manager.send_to_session(ctx.workspace_id, ctx.session_id, {

--- a/app/services/workspace_manager.py
+++ b/app/services/workspace_manager.py
@@ -74,6 +74,9 @@ class WorkspaceManager:
         claudeignore_path = workspace_path / ".claudeignore"
         claudeignore_path.write_text(".workspace_meta.json\n.claudeignore\n")
 
+        # 创建 CLAUDE.md 配置文件
+        self._create_claude_settings(workspace_path)
+
         now = datetime.now()
         meta = {
             "id": workspace_id,
@@ -92,6 +95,17 @@ class WorkspaceManager:
             updated_at=now,
             path=str(workspace_path),
         )
+
+    def _create_claude_settings(self, workspace_path: Path):
+        """创建 .claude/settings.json 配置文件"""
+        claude_dir = workspace_path / ".claude"
+        claude_dir.mkdir(parents=True, exist_ok=True)
+
+        settings_path = claude_dir / "settings.json"
+        if not settings_path.exists():
+            settings_path.write_text(json.dumps({
+                "includeCoAuthoredBy": False
+            }, indent=2))
 
     def create_workspace_with_id(
         self,
@@ -120,6 +134,9 @@ class WorkspaceManager:
         claudeignore_path = workspace_path / ".claudeignore"
         if not claudeignore_path.exists():
             claudeignore_path.write_text(".workspace_meta.json\n.claudeignore\n")
+
+        # 创建 CLAUDE.md 配置文件
+        self._create_claude_settings(workspace_path)
 
         now = datetime.now()
         meta = {
@@ -686,6 +703,9 @@ class WorkspaceManager:
         claudeignore_path = workspace_path / ".claudeignore"
         if not claudeignore_path.exists():
             claudeignore_path.write_text(".workspace_meta.json\n.claudeignore\n")
+
+        # 创建 CLAUDE.md 配置文件
+        self._create_claude_settings(workspace_path)
 
         now = datetime.now()
         meta = {

--- a/client/lib/providers/session_provider.dart
+++ b/client/lib/providers/session_provider.dart
@@ -836,6 +836,14 @@ class SessionNotifier extends StateNotifier<SessionState> {
     } else if (statusType == 'cancelled') {
       // 先停止最后一条消息的 streaming 状态
       _updateLastMessage(sessionId, (m) => m.copyWith(isStreaming: false));
+
+      // 从服务端返回的 cleared_prompts 恢复内容到 draft
+      final clearedPrompts = (data['cleared_prompts'] as List<dynamic>?)?.cast<String>() ?? [];
+      String? restoredDraft;
+      if (clearedPrompts.isNotEmpty) {
+        restoredDraft = clearedPrompts.join('\n');
+      }
+
       // 添加取消状态消息
       _addMessage(
         sessionId,
@@ -844,7 +852,11 @@ class SessionNotifier extends StateNotifier<SessionState> {
           content: message ?? 'Task cancelled',
         ),
       );
-      _updateSession(sessionId, (s) => s.copyWith(isProcessing: false));
+      _updateSession(sessionId, (s) => s.copyWith(
+        isProcessing: false,
+        pendingPrompts: [],  // 清空 pending prompts
+        draft: restoredDraft ?? s.draft,  // 恢复到 draft
+      ));
     }
   }
 

--- a/client/lib/screens/session_screen.dart
+++ b/client/lib/screens/session_screen.dart
@@ -43,6 +43,7 @@ class _SessionScreenState extends ConsumerState<SessionScreen> with WidgetsBindi
   bool _userScrolledUp = false;
   double _lastKeyboardHeight = 0;
   bool _isInputEmpty = true; // 追踪输入框是否为空
+  String _lastDraft = ''; // 追踪 draft 变化（用于取消后恢复）
 
   // 判断是否在底部附近（允许半屏的误差）
   bool get _isAtBottom {
@@ -246,6 +247,18 @@ class _SessionScreenState extends ConsumerState<SessionScreen> with WidgetsBindi
     _lastMessageCount = currentMessageCount;
     _lastContentLength = currentContentLength;
 
+    // 检测 draft 变化（取消任务后恢复 pending prompts 到输入框）
+    final currentDraft = session?.draft ?? '';
+    if (currentDraft != _lastDraft && currentDraft.isNotEmpty && _inputController.text.isEmpty) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted && _inputController.text.isEmpty) {
+          _inputController.text = currentDraft;
+          _inputController.selection = TextSelection.collapsed(offset: currentDraft.length);
+        }
+      });
+    }
+    _lastDraft = currentDraft;
+
     return ScreenScope(
       screenId: 'session',
       child: Scaffold(
@@ -342,6 +355,10 @@ class _SessionScreenState extends ConsumerState<SessionScreen> with WidgetsBindi
                         },
                       ),
           ),
+
+          // Pending prompts（固定在输入栏上方）
+          if (session != null && session.pendingPrompts.isNotEmpty)
+            _buildPendingPrompts(session.pendingPrompts),
 
           // 输入栏
           _buildInputBar(session),

--- a/client/lib/widgets/message_bubble.dart
+++ b/client/lib/widgets/message_bubble.dart
@@ -282,8 +282,11 @@ class _MessageBubbleState extends State<MessageBubble> {
     final resultContent = toolCall.result?['content'] as String?;
     final hasContent = resultContent != null && resultContent.isNotEmpty;
 
+    // 命令文本较长时也可以展开查看完整内容
+    final canExpand = hasContent || displayText.length > 60;
+
     return GestureDetector(
-      onTap: hasContent
+      onTap: canExpand
           ? () {
               setState(() {
                 if (isExpanded) {
@@ -311,11 +314,15 @@ class _MessageBubbleState extends State<MessageBubble> {
           children: [
             // 工具调用头部
             Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Icon(
-                  _getToolIcon(toolCall.name),
-                  size: 14,
-                  color: Theme.of(context).colorScheme.primary,
+                Padding(
+                  padding: const EdgeInsets.only(top: 2),
+                  child: Icon(
+                    _getToolIcon(toolCall.name),
+                    size: 14,
+                    color: Theme.of(context).colorScheme.primary,
+                  ),
                 ),
                 const SizedBox(width: 6),
                 Expanded(
@@ -326,32 +333,41 @@ class _MessageBubbleState extends State<MessageBubble> {
                       color: Theme.of(context).colorScheme.onSurface,
                       fontFamily: toolCall.name == 'Bash' ? 'monospace' : null,
                     ),
-                    overflow: TextOverflow.ellipsis,
-                    maxLines: 2,
+                    overflow: isExpanded ? TextOverflow.visible : TextOverflow.ellipsis,
+                    maxLines: isExpanded ? null : 2,
                   ),
                 ),
                 const SizedBox(width: 6),
                 if (isExecuting)
-                  const SizedBox(
-                    width: 12,
-                    height: 12,
-                    child: CircularProgressIndicator(strokeWidth: 2),
+                  const Padding(
+                    padding: EdgeInsets.only(top: 2),
+                    child: SizedBox(
+                      width: 12,
+                      height: 12,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    ),
                   )
                 else if (hasResult) ...[
-                  Icon(
-                    isError ? Icons.error_outline : Icons.check_circle_outline,
-                    size: 14,
-                    color: isError
-                        ? Theme.of(context).colorScheme.error
-                        : Colors.green,
+                  Padding(
+                    padding: const EdgeInsets.only(top: 2),
+                    child: Icon(
+                      isError ? Icons.error_outline : Icons.check_circle_outline,
+                      size: 14,
+                      color: isError
+                          ? Theme.of(context).colorScheme.error
+                          : Colors.green,
+                    ),
                   ),
                   // 展开/收起指示器
-                  if (hasContent) ...[
+                  if (canExpand) ...[
                     const SizedBox(width: 4),
-                    Icon(
-                      isExpanded ? Icons.expand_less : Icons.expand_more,
-                      size: 16,
-                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    Padding(
+                      padding: const EdgeInsets.only(top: 1),
+                      child: Icon(
+                        isExpanded ? Icons.expand_less : Icons.expand_more,
+                        size: 16,
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
                     ),
                   ],
                 ],


### PR DESCRIPTION
## Summary

### Backend
- Use `.claude/settings.json` with `includeCoAuthoredBy: false` instead of CLAUDE.md for disabling co-author attribution
- Cancel now clears entire pending prompts queue (not just current task)
- Return cleared prompt contents to client for restoration to input box

### Client
- Add `textSelectionTheme` to both light and dark themes for better text selection visibility on colored backgrounds
- Make tool call cards expandable to show full command text when tapped
- Long commands (>60 chars) can be expanded even without result content
- Display pending prompts fixed above input bar (not scrolling with messages)
- Return pending prompt content to input box when task is cancelled
- Reset `isStreaming` and `isExecuting` states when WebSocket connection is lost

## Test plan
- [ ] Create a new workspace, verify `.claude/settings.json` is created with `includeCoAuthoredBy: false`
- [ ] Send a long bash command, verify it can be expanded by tapping the card
- [ ] Queue multiple prompts, cancel task, verify all queued prompts are cleared and content restored to input
- [ ] Select text in code blocks, verify selection color is visible
- [ ] Disconnect network while task running, verify loading indicators stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)